### PR TITLE
Actually index records in indexParallel

### DIFF
--- a/bin/indexParallel
+++ b/bin/indexParallel
@@ -1,19 +1,79 @@
 #!/usr/bin/env bash
-set -x
 set -u
 set -e
-mkdir -p ~/.parallel
-touch ~/.parallel/will-cite
-TABLE=$1
+set -x
+# Default values for options
+START=0
 LIMIT=500
 DELAY=10
-START="${2:-0}"
-MAX=$(mysql -u${DB_USER} -p${DB_PASSWORD} -h${DB_HOST} ${DB_NAME} -B -N  -e "SELECT count(*) FROM ${TABLE} WHERE ! deleted ")
+ADDITIONAL_SQL="WHERE ! deleted"
+JOB_PER_CORE=1
+TABLE=''
+DRYRUN=''
+
+# Function to display usage instructions
+function usage {
+    echo "Usage: $0 <TABLE> [-s <START>] [-l <LIMIT>] [-d <DELAY>] [-j <JOB_PER_CORE>] [--additional-sql <ADDITIONAL_SQL>] [--dryrun]"
+    echo "Options:"
+    echo "  -s, --start        Start index (default: 0)"
+    echo "  -l, --limit        Limit the number of records (default: 500)"
+    echo "  -d, --delay        Delay between parallel jobs in seconds (default: 10)"
+    echo "  -j, --jobs         Number of parallel jobs per core (default: 1)"
+    echo "      --additional-sql Additional SQL condition (default: 'WHERE ! deleted')"
+    echo "      --dryrun       Dry run the indexing"
+    echo "      --help         Display this help message"
+    exit 1
+}
+# Parse options
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -s | --start)
+        START="$2"
+        shift 2
+        ;;
+    -l | --limit)
+        LIMIT="$2"
+        shift 2
+        ;;
+    -d | --delay)
+        DELAY="$2"
+        shift 2
+        ;;
+    -j | --jobs)
+        JOB_PER_CORE="$2"
+        shift 2
+        ;;
+    --additional-sql)
+        ADDITIONAL_SQL="$2"
+        shift 2
+        ;;
+    --dryrun)
+        DRYRUN="--dryrun"
+        shift
+        ;;
+    --help)
+        usage
+        ;;
+    *)
+        TABLE="$1"
+        shift
+        ;;
+    esac
+done
+
+if [[ -z "${TABLE}" ]]; then
+    usage
+fi
+
+mkdir -p ~/.parallel
+touch ~/.parallel/will-cite
+
+MAX=$(mysql -u "${DB_USER}" -p"${DB_PASSWORD}" -h "${DB_HOST}" "${DB_NAME}" -B -N -e "SELECT count(*) FROM ${TABLE} ${ADDITIONAL_SQL}")
+
 export SHELL=$(type -p bash)
 function index {
-    time nice -n19 indexRecordsFromTable $1  --limit=$2 --offset=$3
+    time nice -n 19 indexRecordsFromTable "$1" --limit="$2" --offset="$3"
 }
 export -f index
-DRYRUN=''
-#DRYRUN='--dryrun'
-seq ${START} ${LIMIT} $MAX|parallel ${DRYRUN} --progress --eta --delay ${DELAY} --results /tmp/${TABLE} --line-buffer --tag --joblog /tmp/${TABLE}.log index ${TABLE} ${LIMIT} {}
+JOBS=$(($JOB_PER_CORE * $(nproc)))
+seq ${START} ${LIMIT} $MAX | parallel ${DRYRUN} --jobs $JOBS --progress --eta --delay ${DELAY} --results /tmp/${TABLE} --line-buffer --tag --joblog /tmp/${TABLE}.log index ${TABLE} ${LIMIT} {}

--- a/bin/indexRecordsFromTable
+++ b/bin/indexRecordsFromTable
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
 
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -13,6 +14,72 @@ require_once dirname(__DIR__, 3) . '/autoload.php';
 const ARG_TABLE = 'table';
 const OPT_LIMIT = 'limit';
 const OPT_OFFSET = 'offset';
+/**
+ * Rebuild search index values for records from a table.
+ *
+ * Adapted from @see SearchIndexer::reindexRows()
+ * @param SearchIndexer $indexer
+ * @param Db $db
+ * @param string $table
+ * @param array $ids
+ * @param BaseModel $instance
+ * @param InputInterface $input
+ * @param OutputInterface $output
+ * @param array|null $options
+ * @return true|null
+ * @throws Exception
+ */
+function reindexRows(SearchIndexer   $indexer,
+                     Db              $db,
+                     string          $table,
+                     array           $ids,
+                     BaseModel       $instance,
+                     InputInterface  $input,
+                     OutputInterface $output,
+                     array           $options = null)
+{
+    if (!is_array($ids) && !sizeof($ids)) {
+        return null;
+    }
+    /* Constant that means that only the target ids will be indexed, not records relating to those records*/
+    define('__CollectiveAccess_IS_REINDEXING__', 1);
+
+    $elementIds = null;
+    if (method_exists($instance, "getApplicableElementCodes")) {
+        $elementIds = array_keys($instance->getApplicableElementCodes(null, false, false));
+    }
+
+    $tableName = $instance->tableName();
+    $tableNum = $instance->tableNum();
+    $primaryKey = $instance->primaryKey();
+    $fieldData = [];
+
+    /** @var array $intrinsicList */
+    $intrinsicList = $indexer->getFieldsToIndex($tableName, $tableName, ['intrinsicOnly' => true]);
+    $intrinsicList[$primaryKey] = [];
+    $limit = count($ids);
+    $progress = new ProgressBar($output, $limit ?? 1);
+    $stats = [];
+
+    if ($elementIds) {    // Pre-load attribute values for items to index; improves index performance
+        $output->writeln('Prefetching values');
+        ca_attributes::prefetchAttributes($db, $tableNum, $ids, $elementIds);
+        /** @var DbResult $fieldData */
+        $fieldDataResource = $db->query("SELECT " . join(", ", array_keys($intrinsicList)) . " FROM {$tableName} WHERE {$primaryKey} IN (?)", [$ids]);
+
+        $fieldData = [];
+        while ($fieldDataResource->nextRow()) {
+            $fieldData[(int)$fieldDataResource->get($primaryKey)] = $fieldDataResource->getRow();
+        }
+        $output->writeln('Finished prefetching values');
+    }
+    foreach ($ids as $i => $id) {
+        $ret = $indexer->indexRow($tableNum, $id, $fieldData[$id], true);
+        $stats[$ret] ++;
+        $progress->advance();
+    }
+    return $stats;
+}
 (new SingleCommandApplication())
     ->setName('Reindex records from table')
     ->setDescription('Indexes a portion of records from a table.')
@@ -44,8 +111,12 @@ const OPT_OFFSET = 'offset';
         $indexer = new SearchIndexer($db);
         $n = count($ids);
         $output->writeln("Starting to index $n records from table $table with offset $offset");
-        $indexer->reindexRows($table, $ids);
-        $output->writeln("Indexed $n records from table $table");
+        $success = reindexRows($indexer,$db, $table, $ids, $instance, $input, $output);
+        if ($success) {
+            $output->writeln("Indexed $n records from table $table");
+        } else {
+            throw new Exception('Failed to index rows');
+        }
 
     })
     ->run();

--- a/bin/indexer
+++ b/bin/indexer
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 require_once(getenv('COLLECTIVEACCESS_HOME') . '/setup.php');
-$sleep = getenv('WORKER_INDEXING_SLEEP_TIME');
+$sleep = getenv('WORKER_INDEXING_SLEEP_TIME') ?? 1;
 $sleep = $sleep * 1000000;
 if (ca_search_indexing_queue::lockExists()) {
     if (ca_search_indexing_queue::lockCanBeRemoved()) {

--- a/bin/taskQueue
+++ b/bin/taskQueue
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 require_once(getenv('COLLECTIVEACCESS_HOME') . '/setup.php');
-$sleep = getenv('WORKER_JOB_SLEEP_TIME');
+$sleep = getenv('WORKER_JOB_SLEEP_TIME') ?? 1;
 $sleep = $sleep * 1000000;
 $queue = new TaskQueue();
 $queue->resetUnfinishedTasks();


### PR DESCRIPTION
fix: indexRecordsFromTable now actually indexes more than just the prmary key
feat: add usage instructions to indexParallel script
fix: set default sleep time for indexer and taskQueue if they haven't been set

