### PR TITLE
feat: PROVES-147 Add support for deploying the temporary volume

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -9,6 +9,7 @@ function createDirectories() {
     mkdir -p data
     mkdir -p log
     mkdir -p backups
+    mkdir -p tmp
 }
 
 function linkDirectories() {
@@ -17,10 +18,12 @@ function linkDirectories() {
     rm -rf media
     rm -rf import
     rm -rf app/log
+    rm -rf app/tmp
     ln -sf $APP_ROOT/vendor .
     ln -sf $APP_ROOT/media .
     ln -sf $APP_ROOT/import .
     ln -sf $APP_ROOT/log app/
+    ln -sf $APP_ROOT/tmp app/
     popd
 }
 


### PR DESCRIPTION
* Create ./tmp if it doesn't exist
* Remove contents of vanilla ./app/tmp
* Symlink ./tmp into ./app

Metadata import from task queue runs using the app/tmp directory. If we have the queue in a separate container this needs to be shared as a volume.