### PR TITLE
fix(PROVES-156): Fix failed parallel reindex

### DIFF
--- a/src/Profile/CollectiveaccessMigration.php
+++ b/src/Profile/CollectiveaccessMigration.php
@@ -19,6 +19,7 @@ use Datamodel;
 use Db;
 use Exception;
 use PDO;
+use SearchEngine;
 use Phinx\Migration\AbstractMigration;
 use Symfony\Component\Process\Process;
 


### PR DESCRIPTION
* Error: Class 'CaTools\Profile\SearchEngine' not found in /var/www/html/vendor/gaiaresources/catools/src/Profile/CollectiveaccessMigration.php:578