### PR TITLE
feat: Shorter wait times between indexing jobs when indexing all tables in parallel

### DIFF
--- a/bin/indexParallel
+++ b/bin/indexParallel
@@ -4,7 +4,7 @@ set -e
 # Default values for options
 START=0
 LIMIT=500
-DELAY=1
+DELAY=0.1
 ADDITIONAL_SQL="WHERE ! deleted"
 JOB_PER_CORE=2
 TABLE=''


### PR DESCRIPTION
* 1 second to 0.1 second
* Shaves about an hour off of a full reindex.